### PR TITLE
Update to Meshtastic 2.6.5. Add mirror-urls for mtdev

### DIFF
--- a/org.meshtastic.meshtasticd.metainfo.xml
+++ b/org.meshtastic.meshtasticd.metainfo.xml
@@ -87,11 +87,11 @@
   </screenshots>
 
   <releases>
-    <release version="v2.6.4.b89355f" date="2025-04-10">
-      <url type="details">https://github.com/meshtastic/firmware/releases/tag/v2.6.4.b89355f</url>
-      <description>
-        <p>See GitHub Release notes</p>
-      </description>
+    <release version="2.6.5" date="2025-03-30">
+      <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.6.5</url>
+    </release>
+    <release version="2.6.4" date="2025-03-28">
+      <url type="details">https://github.com/meshtastic/firmware/releases?q=tag%3Av2.6.4</url>
     </release>
   </releases>
 </component>

--- a/org.meshtastic.meshtasticd.yaml
+++ b/org.meshtastic.meshtasticd.yaml
@@ -59,8 +59,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/meshtastic/firmware.git
-        tag: v2.6.4.b89355f
-        commit: b89355ffa60b3893417004b07e7b96f04b17022c
+        tag: v2.6.5.fc3d9f2
+        commit: fc3d9f2a15e201bbedc3a98049abdc8b3bd648da
         x-checker-data:
           is-main-source: true
           type: json
@@ -72,8 +72,8 @@ modules:
         paths:
           - patches/stdcppfs.patch
       - type: archive
-        url: https://github.com/meshtastic/firmware/releases/download/v2.6.4.b89355f/platformio-deps-native-tft-2.6.4.b89355f.zip
-        sha256: de27192190e22b1d6af511c56c19a53b1fcadcff84db5ea63093c607c90c5f32
+        url: https://github.com/meshtastic/firmware/releases/download/v2.6.5.fc3d9f2/platformio-deps-native-tft-2.6.5.fc3d9f2.zip
+        sha256: 4dc9f8701b7a0f8f5f94076f017e0316bb87ec10145bfb88da77e9d66101d1b2
         strip-components: 1
         dest: pio
         x-checker-data:
@@ -198,6 +198,9 @@ modules:
             sources:
               - type: archive
                 url: https://bitmath.org/code/mtdev/mtdev-1.1.7.tar.bz2
+                mirror-urls:
+                  - https://ftp.osuosl.org/pub/blfs/conglomeration/mtdev/mtdev-1.1.7.tar.bz2
+                  - https://mirror.freedif.org/pub/blfs/conglomeration/mtdev/mtdev-1.1.7.tar.bz2
                 sha256: a107adad2101fecac54ac7f9f0e0a0dd155d954193da55c2340c97f2ff1d814e
                 x-checker-data:
                   type: anitya


### PR DESCRIPTION
- Adds `mirror-urls` for mtdev. The `bitmath.org` host is timing out consistently.
- Updates to Meshtastic 2.6.5
  - Should fix issues with PlatformIO attempting to fetch packages from the internet.
- Updates metainfo.xml file
  - Moved upstream starting with 2.6.6 (still in testing) https://github.com/meshtastic/firmware/blob/v2.6.6.54c1423/bin/org.meshtastic.meshtasticd.metainfo.xml

Resolves #7 