### PR TITLE
Update meshtasticd to v2.7.23

### DIFF
--- a/org.meshtastic.meshtasticd.yaml
+++ b/org.meshtastic.meshtasticd.yaml
@@ -44,14 +44,9 @@ modules:
       - desktop-file-edit --set-key="Exec" --set-value="meshtasticd-wrapper.sh %U"
         /app/share/applications/org.meshtastic.meshtasticd.desktop
       - install -Dm644 -t /app/share/metainfo bin/org.meshtastic.meshtasticd.metainfo.xml
-      # Set platformio cache to always expire in the future (append '1' to timestamps)
-      - >
-        tj=$(mktemp) &&
-        jq -c 'with_entries(.value |= (. | tostring + "1" | tonumber))' pio/core/.cache/downloads/usage.db
-        > "$tj" && mv "$tj" pio/core/.cache/downloads/usage.db
       # Build meshtasticd
       - platformio run -e native-tft --disable-auto-clean
-      - install -Dm755 .pio/build/native-tft/program /app/bin/meshtasticd
+      - install -Dm755 .pio/build/native-tft/meshtasticd /app/bin/meshtasticd
       # Install the default config files and directories
       - install -d /app/share/meshtasticd
       - install -d /app/share/meshtasticd/config.d
@@ -66,8 +61,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/meshtastic/firmware.git
-        tag: v2.7.16.a597230
-        commit: a59723030a7e15ab53b6fd1cb264ba2eebd4ed46
+        tag: v2.7.23.b246bcd
+        commit: b246bcd72ec6989b803da0d83d217b045303d3c6
         x-checker-data:
           is-main-source: true
           type: json
@@ -79,8 +74,8 @@ modules:
         paths:
           - patches/stdcppfs.patch
       - type: archive
-        url: https://github.com/meshtastic/firmware/releases/download/v2.7.16.a597230/platformio-deps-native-tft-2.7.16.a597230.zip
-        sha256: c5bd2306b82623187f688c33a1a1912b5120d0f3f5a3ba05851ef1069a551ee4
+        url: https://github.com/meshtastic/firmware/releases/download/v2.7.23.b246bcd/platformio-deps-native-tft-2.7.23.b246bcd.zip
+        sha256: 66c46e5839fdd9fe2dfcd51597bb81e1ee525ac3e3c7ace30751b6fd8c729589
         strip-components: 1
         dest: pio
         x-checker-data:

--- a/patches/stdcppfs.patch
+++ b/patches/stdcppfs.patch
@@ -1,12 +1,12 @@
-diff --git a/arch/portduino/portduino.ini b/arch/portduino/portduino.ini
-index aa1150e9..26377345 100644
---- a/arch/portduino/portduino.ini
-+++ b/arch/portduino/portduino.ini
-@@ -35,7 +35,6 @@ build_flags =
-   -DRADIOLIB_EEPROM_UNSUPPORTED
+diff --git a/variants/native/portduino.ini b/variants/native/portduino.ini
+index 9ab45d1ab..cb86a1a83 100644
+--- a/variants/native/portduino.ini
++++ b/variants/native/portduino.ini
+@@ -62,7 +62,6 @@ build_flags =
+   -D_FORTIFY_SOURCE=2
+   -fstack-protector-all -Wstack-protector --param ssp-buffer-size=4
    -DPORTDUINO_LINUX_HARDWARE
-   -lpthread
 -  -lstdc++fs
    -lbluetooth
    -lgpiod
-   -lyaml-cpp
+   -li2c

--- a/python3-requirements.yaml
+++ b/python3-requirements.yaml
@@ -7,7 +7,7 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "platformio==6.1.18" --no-build-isolation
+        --prefix=${FLATPAK_DEST} "platformio==6.1.19" --no-build-isolation
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/cf/6f/6abff7fe6813e6f94129a50c8c70bf70fb33ed2515b1037e703cef6d7a7e/ajsonrpc-1.2.0-py3-none-any.whl
@@ -28,8 +28,8 @@ modules:
         url: https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl
         sha256: 3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d
       - type: file
-        url: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
-        sha256: ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
+        url: https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl
+        sha256: a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
       - type: file
         url: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
         sha256: 4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
@@ -43,8 +43,8 @@ modules:
         url: https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl
         sha256: 013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73
       - type: file
-        url: https://files.pythonhosted.org/packages/23/25/e6a3bf27ddc146f5a48a50f17e54cac5f3fd88c8474228791df4e0d031a8/platformio-6.1.18-py3-none-any.whl
-        sha256: 94ef70a242ddcb93e020b0250c4f61e65b347411e8dfe36f79efb759c09324fa
+        url: https://files.pythonhosted.org/packages/cf/15/ecb78457241aef59977cafe52b521ed99c7f42e78016d55bbaa953a2b6ae/platformio-6.1.19-py3-none-any.whl
+        sha256: 4f93b00cf2759035d76ebece4840a3274096f7343ee5bba56cbc0bc3ce2eb6f5
       - type: file
         url: https://files.pythonhosted.org/packages/af/43/700932c4f0638c3421177144a2e86448c0d75dbaee2c7936bda3f9fd0878/pyelftools-0.32-py3-none-any.whl
         sha256: 013df952a006db5e138b1edf6d8a68ecc50630adbd0d83a2d41e7f846163d738
@@ -58,8 +58,8 @@ modules:
         url: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
         sha256: de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177
       - type: file
-        url: https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl
-        sha256: 595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35
+        url: https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl
+        sha256: 0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74
       - type: file
         url: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
         sha256: f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3
@@ -67,8 +67,8 @@ modules:
         url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
         sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
       - type: file
-        url: https://files.pythonhosted.org/packages/6d/0d/8adfeaa62945f90d19ddc461c55f4a50c258af7662d34b6a3d5d1f8646f6/uvicorn-0.34.3-py3-none-any.whl
-        sha256: 16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885
+        url: https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl
+        sha256: c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee
       - type: file
         url: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
         sha256: 61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 #
 # pipx install flatpak-pip-generator
 # flatpak_pip_generator --requirements-file=requirements.txt --yaml
-platformio==6.1.18
+platformio==6.1.19
 nanopb==0.4.9.1
 grpcio-tools


### PR DESCRIPTION
This pull request updates dependencies and build configurations for `meshtasticd` and its Python requirements, as well as refines a build patch. The main focus is on upgrading to newer versions of the firmware and several Python packages, ensuring compatibility and access to recent features and fixes.

**Dependency and Build Updates:**

*Firmware and Build System:*
- Updated the Meshtastic firmware source and related PlatformIO dependencies to version `v2.7.23.b246bcd` for improved stability and features. [[1]](diffhunk://#diff-d3c5fb3eeb55127674fdf1a5c5d3a0372a958999ba9d3c11bbb2acf47328fb79L69-R70) [[2]](diffhunk://#diff-d3c5fb3eeb55127674fdf1a5c5d3a0372a958999ba9d3c11bbb2acf47328fb79L82-R83)
- Changed the build output path for the `meshtasticd` binary in the install command to match the new firmware build structure.

*Python Requirements:*
- Upgraded several Python dependencies to newer versions, including:
  - `platformio` to `6.1.19` [[1]](diffhunk://#diff-ab4da5284b65c58cbb721ea771f56a937d44269ddc0ed00c28b12a273233bb61L10-R10) [[2]](diffhunk://#diff-ab4da5284b65c58cbb721ea771f56a937d44269ddc0ed00c28b12a273233bb61L46-R47)
  - `click` to `8.3.3`
  - `starlette` to `0.52.1`
  - `uvicorn` to `0.40.0`

*Build Patch Adjustment:*
- Updated `stdcppfs.patch` to apply the removal of `-lstdc++fs` to the correct `portduino.ini` file location in the new firmware structure.