### PR TITLE
Update libinput to v1.31.3

### DIFF
--- a/org.meshtastic.meshtasticd.yaml
+++ b/org.meshtastic.meshtasticd.yaml
@@ -183,8 +183,8 @@ modules:
           - -Dzshcompletiondir=no
         sources:
           - type: archive
-            url: https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.31.2/libinput-1.31.2.tar.gz
-            sha256: 507a40b8a74568ed7c2bd05acf2e15ee3d9f4703102dca86d4f6a804e73bf1f6
+            url: https://gitlab.freedesktop.org/libinput/libinput/-/archive/1.31.3/libinput-1.31.3.tar.gz
+            sha256: b6749bf6f1890f6631c0a70a027c35fec9d2e096a39f720548896e41474a9854
             x-checker-data:
               type: anitya
               project-id: 5781


### PR DESCRIPTION
This pull request updates the `libinput` dependency to a newer version in the `org.meshtastic.meshtasticd.yaml` configuration file.

Dependency updates:

* Updated `libinput` from version 1.31.2 to 1.31.3, including the corresponding archive URL and SHA256 checksum.