### PR TITLE
Update libgpiod to v2.2.5

### DIFF
--- a/org.meshtastic.meshtasticd.yaml
+++ b/org.meshtastic.meshtasticd.yaml
@@ -120,8 +120,8 @@ modules:
         buildsystem: autotools
         sources:
           - type: archive
-            url: https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-2.2.4.tar.gz
-            sha256: 8b201d7a665e9108cf1cef24fe59d567fcacc818a36e17cfee046dd96eafbb84
+            url: https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-2.2.5.tar.gz
+            sha256: 3a093cabe19bd5077f9f1bf31c8d4743cba3276718fca007f8eb6392a3bce575
             x-checker-data:
               type: anitya
               project-id: 20640


### PR DESCRIPTION
This pull request updates the version of the `libgpiod` dependency used in the project.

Dependency updates:

* Upgraded `libgpiod` from version 2.2.4 to 2.2.5 in `org.meshtastic.meshtasticd.yaml`, updating the source URL and SHA256 checksum to match the new release.