### PR TITLE
Update meshtasticd to v2.7.26

### DIFF
--- a/org.meshtastic.meshtasticd.yaml
+++ b/org.meshtastic.meshtasticd.yaml
@@ -44,11 +44,6 @@ modules:
       - desktop-file-edit --set-key="Exec" --set-value="meshtasticd-wrapper.sh %U"
         /app/share/applications/org.meshtastic.meshtasticd.desktop
       - install -Dm644 -t /app/share/metainfo bin/org.meshtastic.meshtasticd.metainfo.xml
-      # Rewrite platformio cache to always expire in the future (append '1' to timestamps)
-      - >
-        tj=$(mktemp) &&
-        jq -c 'with_entries(.value |= (. | tostring + "1" | tonumber))' pio/core/.cache/downloads/usage.db
-        > "$tj" && mv "$tj" pio/core/.cache/downloads/usage.db
       # Rewrite platformio-deps appstate version to match the current version
       - >
         tp=$(mktemp) && pio_version=$(platformio --version | awk '{print $NF}') &&
@@ -57,7 +52,7 @@ modules:
         echo "Set PlatformIO version to $pio_version in pio/core/appstate.json"
       # Build meshtasticd
       - platformio run -e native-tft --disable-auto-clean
-      - install -Dm755 .pio/build/native-tft/program /app/bin/meshtasticd
+      - install -Dm755 .pio/build/native-tft/meshtasticd /app/bin/meshtasticd
       # Install the default config files and directories
       - install -d /app/share/meshtasticd
       - install -d /app/share/meshtasticd/config.d
@@ -72,8 +67,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/meshtastic/firmware.git
-        tag: v2.7.16.a597230
-        commit: a59723030a7e15ab53b6fd1cb264ba2eebd4ed46
+        tag: v2.7.26.54e0d8d
+        commit: 54e0d8d0ab2ff56b3a9ce967e53f79e49af560fb
         x-checker-data:
           is-main-source: true
           type: json
@@ -85,8 +80,8 @@ modules:
         paths:
           - patches/stdcppfs.patch
       - type: archive
-        url: https://github.com/meshtastic/firmware/releases/download/v2.7.16.a597230/platformio-deps-native-tft-2.7.16.a597230.zip
-        sha256: c5bd2306b82623187f688c33a1a1912b5120d0f3f5a3ba05851ef1069a551ee4
+        url: https://github.com/meshtastic/firmware/releases/download/v2.7.26.54e0d8d/platformio-deps-native-tft-2.7.26.54e0d8d.zip
+        sha256: 9ce0661d576e0297213890872399379e0faa7c4c1210d8e43ff16114f6860632
         strip-components: 1
         dest: pio
         x-checker-data:

--- a/patches/stdcppfs.patch
+++ b/patches/stdcppfs.patch
@@ -1,12 +1,12 @@
-diff --git a/arch/portduino/portduino.ini b/arch/portduino/portduino.ini
-index aa1150e9..26377345 100644
---- a/arch/portduino/portduino.ini
-+++ b/arch/portduino/portduino.ini
-@@ -35,7 +35,6 @@ build_flags =
-   -DRADIOLIB_EEPROM_UNSUPPORTED
+diff --git a/variants/native/portduino.ini b/variants/native/portduino.ini
+index 9ab45d1ab..cb86a1a83 100644
+--- a/variants/native/portduino.ini
++++ b/variants/native/portduino.ini
+@@ -62,7 +62,6 @@ build_flags =
+   -D_FORTIFY_SOURCE=2
+   -fstack-protector-all -Wstack-protector --param ssp-buffer-size=4
    -DPORTDUINO_LINUX_HARDWARE
-   -lpthread
 -  -lstdc++fs
    -lbluetooth
    -lgpiod
-   -lyaml-cpp
+   -li2c


### PR DESCRIPTION
This pull request updates the `org.meshtastic.meshtasticd.yaml` build configuration and related patch to support the latest upstream firmware release and corrects the binary installation path. The most important changes are grouped below:

**Upstream firmware and dependencies update:**

* Updated the main firmware source to tag `v2.7.26.54e0d8d` and commit `54e0d8d0ab2ff56b3a9ce967e53f79e49af560fb` to use the latest upstream version.
* Updated the PlatformIO dependencies archive URL and checksum to match the new firmware version.

**Build process fixes:**

* Corrected the installed binary path from `.pio/build/native-tft/program` to `.pio/build/native-tft/meshtasticd` to match the output of the new firmware build.
* Removed the step that rewrote the PlatformIO cache timestamps, as it is no longer needed.

**Patch maintenance:**

* Updated the `stdcppfs.patch` to target the correct file (`variants/native/portduino.ini` instead of `arch/portduino/portduino.ini`) and ensure the `-lstdc++fs` linker flag is removed from the native variant.