### PR TITLE
Update platformio to v6.1.19

### DIFF
--- a/org.meshtastic.meshtasticd.yaml
+++ b/org.meshtastic.meshtasticd.yaml
@@ -44,11 +44,17 @@ modules:
       - desktop-file-edit --set-key="Exec" --set-value="meshtasticd-wrapper.sh %U"
         /app/share/applications/org.meshtastic.meshtasticd.desktop
       - install -Dm644 -t /app/share/metainfo bin/org.meshtastic.meshtasticd.metainfo.xml
-      # Set platformio cache to always expire in the future (append '1' to timestamps)
+      # Rewrite platformio cache to always expire in the future (append '1' to timestamps)
       - >
         tj=$(mktemp) &&
         jq -c 'with_entries(.value |= (. | tostring + "1" | tonumber))' pio/core/.cache/downloads/usage.db
         > "$tj" && mv "$tj" pio/core/.cache/downloads/usage.db
+      # Rewrite platformio-deps appstate version to match the current version
+      - >
+        tp=$(mktemp) && pio_version=$(platformio --version | awk '{print $NF}') &&
+        jq -c --arg v "$pio_version" '.last_version = $v' pio/core/appstate.json > "$tp" &&
+        mv "$tp" pio/core/appstate.json &&
+        echo "Set PlatformIO version to $pio_version in pio/core/appstate.json"
       # Build meshtasticd
       - platformio run -e native-tft --disable-auto-clean
       - install -Dm755 .pio/build/native-tft/program /app/bin/meshtasticd

--- a/python3-requirements.yaml
+++ b/python3-requirements.yaml
@@ -7,7 +7,7 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "platformio==6.1.18" --no-build-isolation
+        --prefix=${FLATPAK_DEST} "platformio==6.1.19" --no-build-isolation
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/cf/6f/6abff7fe6813e6f94129a50c8c70bf70fb33ed2515b1037e703cef6d7a7e/ajsonrpc-1.2.0-py3-none-any.whl
@@ -28,8 +28,8 @@ modules:
         url: https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl
         sha256: 3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d
       - type: file
-        url: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
-        sha256: ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
+        url: https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl
+        sha256: a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613
       - type: file
         url: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
         sha256: 4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
@@ -43,8 +43,8 @@ modules:
         url: https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl
         sha256: 013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73
       - type: file
-        url: https://files.pythonhosted.org/packages/23/25/e6a3bf27ddc146f5a48a50f17e54cac5f3fd88c8474228791df4e0d031a8/platformio-6.1.18-py3-none-any.whl
-        sha256: 94ef70a242ddcb93e020b0250c4f61e65b347411e8dfe36f79efb759c09324fa
+        url: https://files.pythonhosted.org/packages/cf/15/ecb78457241aef59977cafe52b521ed99c7f42e78016d55bbaa953a2b6ae/platformio-6.1.19-py3-none-any.whl
+        sha256: 4f93b00cf2759035d76ebece4840a3274096f7343ee5bba56cbc0bc3ce2eb6f5
       - type: file
         url: https://files.pythonhosted.org/packages/46/2a/f9697576603dae937727827505a6126a066affb227034e77e6f9068910da/pyelftools-0.33-py3-none-any.whl
         sha256: f215ad5f47d3f1373a21496a6c9e0707c622840d0622f23ff7ce08678b020036
@@ -58,8 +58,8 @@ modules:
         url: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
         sha256: de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177
       - type: file
-        url: https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl
-        sha256: 595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35
+        url: https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl
+        sha256: 0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74
       - type: file
         url: https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl
         sha256: f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3
@@ -67,8 +67,8 @@ modules:
         url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
         sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
       - type: file
-        url: https://files.pythonhosted.org/packages/6d/0d/8adfeaa62945f90d19ddc461c55f4a50c258af7662d34b6a3d5d1f8646f6/uvicorn-0.34.3-py3-none-any.whl
-        sha256: 16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885
+        url: https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl
+        sha256: c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee
       - type: file
         url: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
         sha256: 61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 #
 # pipx install flatpak-pip-generator
 # flatpak_pip_generator --requirements-file=requirements.txt --yaml
-platformio==6.1.18
+platformio==6.1.19
 nanopb==0.4.9.1
 grpcio-tools


### PR DESCRIPTION
Replaces #32

---
🤖

This pull request updates several Python dependencies and improves the PlatformIO build process for `meshtasticd`. The main changes include upgrading key Python packages, ensuring PlatformIO version consistency, and updating the handling of PlatformIO's cache and appstate files.

**Dependency updates:**

* Upgraded `platformio` from version 6.1.18 to 6.1.19, including updating the source URL and SHA256 hash in `python3-requirements.yaml`. [[1]](diffhunk://#diff-ab4da5284b65c58cbb721ea771f56a937d44269ddc0ed00c28b12a273233bb61L10-R10) [[2]](diffhunk://#diff-ab4da5284b65c58cbb721ea771f56a937d44269ddc0ed00c28b12a273233bb61L46-R47)
* Upgraded `click` from 8.1.7 to 8.3.3, `starlette` from 0.46.2 to 0.52.1, and `uvicorn` from 0.34.3 to 0.40.0, with corresponding URL and hash updates. [[1]](diffhunk://#diff-ab4da5284b65c58cbb721ea771f56a937d44269ddc0ed00c28b12a273233bb61L31-R32) [[2]](diffhunk://#diff-ab4da5284b65c58cbb721ea771f56a937d44269ddc0ed00c28b12a273233bb61L61-R71)

**Build process improvements:**

* Added a build step to rewrite the `platformio-deps` appstate version in `pio/core/appstate.json` to match the current PlatformIO version, ensuring version consistency during builds.
* Clarified and updated the handling of PlatformIO's cache expiration logic.