### PR TITLE
freedesktop 26.08

### DIFF
--- a/org.meshtastic.meshtasticd.yaml
+++ b/org.meshtastic.meshtasticd.yaml
@@ -1,6 +1,6 @@
 id: org.meshtastic.meshtasticd
 runtime: org.freedesktop.Platform
-runtime-version: '25.08'
+runtime-version: '26.08'
 sdk: org.freedesktop.Sdk
 command: meshtasticd-wrapper.sh
 


### PR DESCRIPTION
Update freedesktop runtime version to 26.08
https://www.phoronix.com/news/FreeDesktop-SDK-26.08